### PR TITLE
Add option to automatically create non-existing parent directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ PCRE_LIBS = $(shell pkg-config --libs libpcre)
 
 all: rewritefs
 
-rewritefs: rewritefs.o rewrite.o
-	gcc rewritefs.o rewrite.o $(FUSE_LIBS) $(PCRE_LIBS) $(LDFLAGS) -o $@
+rewritefs: rewritefs.o rewrite.o util.o
+	gcc $^ $(FUSE_LIBS) $(PCRE_LIBS) $(LDFLAGS) -o $@
 
 %.o: %.c
 	gcc $(CFLAGS) $(FUSE_CFLAGS) $(PCRE_CFLAGS) -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 MANDIR = $(PREFIX)/share/man
-CFLAGS = -Wall -O2
-LDFLAGS = 
+CFLAGS += -Wall -O2
 
 FUSE_CFLAGS = $(shell pkg-config --cflags fuse)
 FUSE_LIBS = $(shell pkg-config --libs fuse)

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ If rewritten-path is **.**, it means "don't rewrite anything".
   
 . and .. will never be proposed to be translated.
   
-You can access to matched parenthesis with \1, \2... (not yet implemented)
+You can access captured groups as backreferences (`\1`, `\2`, …).
 
 A regular expression can be written in more than one line, in particular in
 conjunction with the **x** flag.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ to mount the "rewritten" filesystem, for example :
 Then, accessing to files in /home/me will follow rules defined in your config
 file.
 
+### Directory auto-creation
+
+When using backreferences of in rules of the form…
+
+    /(.+) - (.+)/ \1/\2
+
+…it is possible that the directory into which an operation is being redirected
+does not exist yet. To support such rules, rewritefs may be invoked with the
+option `-o autocreate`. This option will cause rewritefs to automatically create
+all non-existing parent directories when a path is being rewritten.
+
+Note that, due to FUSE limitations, the parent directories will be created using
+the umask with which rewritefs has been invoked, instead of the umask of the
+process requesting accessing the file.
+
 ## Using rewritefs with mount(8) or fstab(5)
 
     mount.fuse rewritefs#/mnt/home/me /home/me -o config=/mnt/home/me/.config/rewritefs,allow_other

--- a/rewrite.c
+++ b/rewrite.c
@@ -8,12 +8,14 @@
 #include <ctype.h>
 #include <string.h>
 #include <errno.h>
+#include <assert.h>
 
 #include <fuse.h>
 #include <fuse_opt.h>
 #include <pcre.h>
 
 #include "rewrite.h"
+#include "util.h"
 
 #define DEBUG(lvl, x...) if(config.verbose >= lvl) fprintf(stderr, x)
 
@@ -449,24 +451,56 @@ char *apply_rule(const char *path, struct rewrite_rule *rule) {
     /* Fill ovector */
     nvec = (rule->filename_regexp->captures + 1) * 3;
     ovector = calloc(nvec, sizeof(int));
-    pcre_exec(rule->filename_regexp->regexp, rule->filename_regexp->extra, path+1,
-        strlen(path)-1, 0, 0, ovector, nvec);
-    
-    /* rewritten = orig_fs + part of path before the matched part + rewritten_path + part of path after the matched path */
-    rewritten = malloc(strlen(config.orig_fs) + strlen(rule->rewritten_path) + 1 /* \0 */ + 
-        1 + ovector[0] + /* before */
-        strlen(path) - ovector[1] /* after */);
+    int scount = pcre_exec(rule->filename_regexp->regexp,
+                           rule->filename_regexp->extra, path+1,
+                           strlen(path)-1, 0, 0, ovector, nvec);
+
+    /* Replace backreferences */
+    char *rewritten_path = malloc(strlen(rule->rewritten_path) + 1);
+    strcpy(rewritten_path, rule->rewritten_path);
+    for (int i=1; i<=rule->filename_regexp->captures; i++) {
+      // Since we are replacing rewritten_path with a newly allocated string, we
+      // are keeping a reference around so we can free() it later.
+      char *rewritten_path_free_later = rewritten_path;
+
+      const char *substr;
+      int substr_len = pcre_get_substring(path+1, ovector, scount, i, &substr);
+      assert(substr_len >= 0);
+
+      // Construct the backreference expression (we currently have int, but we
+      // want a string of the form "\1").
+      const int replace_from_len = snprintf(NULL, 0, "\\%d", i);
+      char *replacement_from = malloc(replace_from_len + 1);
+      const int written = snprintf(replacement_from, replace_from_len+1, "\\%d", i);
+      assert(written == replace_from_len);
+
+      rewritten_path = string_replace(rewritten_path, replacement_from, substr);
+      assert(rewritten_path);
+
+      free(replacement_from);
+      free(rewritten_path_free_later);
+      pcre_free_substring(substr);
+    }
+
     DEBUG(4, "  orig_fs = %s\n",  config.orig_fs);
     DEBUG(4, "  begin = %s\n", strndup(path, ovector[0] + 1));
     DEBUG(4, "  rewritten = %s\n", rule->rewritten_path);
     DEBUG(4, "  end = %s\n", path + 1 + ovector[1]);
+
+    /* rewritten = orig_fs + part of path before the matched part +
+       rewritten_path + part of path after the matched path */
+    rewritten = malloc(strlen(config.orig_fs) + strlen(rewritten_path)
+                       + 1 /* \0 */
+                       + 1 + ovector[0] /* before */
+                       + strlen(path) - ovector[1] /* after */);
     strcpy(rewritten, config.orig_fs);
     strncat(rewritten, path, 1 + ovector[0]);
-    strcat(rewritten, rule->rewritten_path); /* XXX replace \1 ... \n if needed */
+    strcat(rewritten, rewritten_path);
     strcat(rewritten, path + 1 + ovector[1]);
-    
+
+    free(rewritten_path);
     free(ovector);
-    
+
     DEBUG(1, "  %s -> %s\n", path, rewritten);
     DEBUG(3, "\n");
     return rewritten;

--- a/rewritefs.1
+++ b/rewritefs.1
@@ -84,6 +84,25 @@ rewritefs \-o config=/mnt/home/me/\.config/rewritefs /mnt/home/me /home/me
 .P
 Then, accessing to files in /home/me will follow rules defined in your config file\.
 .
+.SS "Directory auto\-creation"
+When using backreferences of in rules of the form…
+.
+.IP "" 4
+.
+.nf
+
+/(\.+) \- (\.+)/ \e1/\e2
+.
+.fi
+.
+.IP "" 0
+.
+.P
+…it is possible that the directory into which an operation is being redirected does not exist yet\. To support such rules, rewritefs may be invoked with the option \fB\-o autocreate\fR\. This option will cause rewritefs to automatically create all non\-existing parent directories when a path is being rewritten\.
+.
+.P
+Note that, due to FUSE limitations, the parent directories will be created using the umask with which rewritefs has been invoked, instead of the umask of the process requesting accessing the file\.
+.
 .SH "Using rewritefs with mount(8) or fstab(5)"
 .
 .nf

--- a/rewritefs.1
+++ b/rewritefs.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "REWRITEFS" "1" "March 2016" "" ""
+.TH "REWRITEFS" "1" "April 2017" "" ""
 .
 .SH "NAME"
 \fBrewritefs\fR \- mod_rewrite\-like FUSE filesystem
@@ -230,7 +230,7 @@ If rewritten\-path is \fB\.\fR, it means "don\'t rewrite anything"\.
 \&\. and \.\. will never be proposed to be translated\.
 .
 .P
-You can access to matched parenthesis with \e1, \e2\.\.\. (not yet implemented)
+You can access captured groups as backreferences (\fB\e1\fR, \fB\e2\fR, …)\.
 .
 .P
 A regular expression can be written in more than one line, in particular in conjunction with the \fBx\fR flag\.

--- a/rewritefs.c
+++ b/rewritefs.c
@@ -585,8 +585,6 @@ static struct fuse_operations rewrite_oper = {
 
 int main(int argc, char *argv[]) {
     struct fuse_args args = FUSE_ARGS_INIT(argc, argv);
-
-    umask(0);
     parse_args(argc, argv, &args);
     return fuse_main(args.argc, args.argv, &rewrite_oper, NULL);
 }

--- a/util.c
+++ b/util.c
@@ -1,0 +1,44 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* Replace the first occurrence of `from` in `source` by `to` and return the
+   result as a newly allocated string. If `from` is not found in `source` return
+   NULL. */
+char *string_replace(const char *source, const char *from, const char *to) {
+  char *found = strstr(source, from);
+  if (!found) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  size_t source_len = strlen(source);
+  size_t from_len = strlen(from);
+  size_t to_len = strlen(to);
+
+  size_t substring_begin = found - source;
+  size_t substring_end = substring_begin + from_len;
+
+  size_t before_len = substring_begin;
+  size_t after_len = source_len - substring_end;
+  size_t dest_len = before_len + to_len + after_len;
+
+  // Part preceeding `from`.
+  char *before = malloc(before_len + 1);
+  strncpy(before, source, before_len);
+  *(before + before_len) = 0;
+
+  // Part succeeding `from`.
+  const char *after = source + substring_end;
+
+  char *dest = malloc(dest_len + 1);
+  int written = snprintf(dest, dest_len + 1, "%s%s%s", before, to, after);
+  assert(written == dest_len);
+
+  free(before);
+  return dest;
+}

--- a/util.h
+++ b/util.h
@@ -1,0 +1,1 @@
+char *string_replace(const char *source, const char *from, const char *to);

--- a/util.h
+++ b/util.h
@@ -1,1 +1,3 @@
 char *string_replace(const char *source, const char *from, const char *to);
+
+int mkdir_parents(const char *path, mode_t mode);


### PR DESCRIPTION
This builds on #5 to support a usecase where backreferences are used to dynamically create a new destination path. I.e., while backreferences allow rules like:

```
/(.+) - (.+) - (.+)/ ⇒  \1/\2/\3
```

…then these rules run into trouble where the rewritten parent directories don’t yet exist. Since the rules are dynamic, a user cannot create them ahead of time. That’s why this adds an option `-o autocreate`, which will `mkdir()` the respective directories during rewriting.

My usecase for this is I have software reading and writing flat files using such a pattern without any configuration options. Since the usecase entails millions of files, file-system performance suffers from the bloated, flat directory.

Potentially, this could be useful to others.